### PR TITLE
Flashy, Hashy, Cachey

### DIFF
--- a/jetski.cabal
+++ b/jetski.cabal
@@ -16,9 +16,12 @@ library
                      , ambiata-p
                      , ambiata-x-eithert
                      , bytestring                      == 0.10.*
+                     , cryptonite                      == 0.15.*
                      , directory                       == 1.2.*
                      , exceptions                      >= 0.6        && < 0.9
+                     , filepath                        == 1.4.*
                      , libffi                          == 0.1.*
+                     , memory                          == 0.13.*
                      , process                         >= 1.2.3      && < 1.5
                      , temporary                       == 1.2.*
                      , text                            == 1.2.*
@@ -32,8 +35,8 @@ library
                        src
 
   exposed-modules:
-                       Paths_ambiata_jetski
                        Jetski
+                       Jetski.Hash
                        Jetski.OS
 
 test-suite test

--- a/src/Jetski/Hash.hs
+++ b/src/Jetski/Hash.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Jetski.Hash (
+    Hash(..)
+  , renderHash
+  , hashBytes
+  , hashText
+  , hashHashes
+  ) where
+
+import           Crypto.Hash (Digest, SHA1)
+import qualified Crypto.Hash as Hash
+
+import           Data.ByteArray (ByteArrayAccess, convert)
+import           Data.ByteArray.Encoding (Base(..), convertToBase)
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as L
+import qualified Data.Text.Encoding as T
+
+import           P
+
+
+newtype Hash =
+  Hash {
+      unHash :: Digest SHA1
+    } deriving (Eq, Ord, Show)
+
+renderHash :: Hash -> Text
+renderHash =
+  T.decodeUtf8 . takeBase16 . unHash
+
+takeBytes :: ByteArrayAccess a => a -> ByteString
+takeBytes =
+  convert
+
+takeBase16 :: ByteArrayAccess a => a -> ByteString
+takeBase16 =
+  convertToBase Base16
+
+hashBytes :: ByteString -> Hash
+hashBytes bytes = do
+  Hash (Hash.hash bytes)
+
+hashText :: Text -> Hash
+hashText text = do
+  hashBytes (T.encodeUtf8 text)
+
+hashHashes :: [Hash] -> Hash
+hashHashes =
+  Hash . Hash.hashlazy . L.fromChunks . fmap (takeBytes . unHash)


### PR DESCRIPTION
`compileLibrary` now takes a parameter `CacheLibrary` which decides whether or not the compiled stuff ends up in `JETSKI_HOME` (default `$HOME/.jetski`) or in `TMPDIR`.

If it goes in `TMPDIR` then it still gets deleted as usual, otherwise we just leave it be.

The hash includes the source code and the options used to build.

I won't merge this until I've checked everything works well in icicle / ice, but feel free to review the actual code.

! @amosr @tranma 