### PR TITLE
Replace 'libffi' bindings with our own

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,54 +11,30 @@ Overview
 
 `jetski` is a library which allows for runtime compilation and execution of C code.
 
+![takeoff](img/takeoff.jpg)
+
 
 Example
 -------
 
 ```haskell
 source :: Text
-source = T.unlines [ "double mean(double sum, double count) {"
-                   , "    return sum / count;"
-                   , "}"
-                   , ""
-                   , "double max(double x, double y) {"
-                   , "    return x > y ? x : y;"
-                   , "}"
+source =
+  T.unlines [
+      "double mean(double sum, double count) {"
+    , "    return sum / count;"
+    , "}"
+    , ""
+    , "double max(double x, double y) {"
+    , "    return x > y ? x : y;"
+    , "}"
+    ]
 
 mean :: Double -> Double -> IO (Either JetskiError Double)
 mean sum count =
   runEitherT $ withLibrary [] source $ \library -> do
     mean <- function library "mean" retDouble
-    mean sum count
+    mean [argDouble sum, argDouble count]
 ```
 
 ![barrel-flip](img/barrel-flip.jpg)
-
-
-Dependencies
-------------
-
-To build this project you'll need `libffi` installed and available to `pkgconfig`.
-
-### OS/X
-
-**Install:**
-```bash
-brew install libffi
-brew install pkg-config
-```
-
-**Configure:**
-```bash
-export BREW_LIBFFI=$(brew --prefix libffi)
-export PKG_CONFIG_PATH=$BREW_LIBFFI/lib/pkgconfig
-```
-
-### RHEL/CentOS
-
-**Install:**
-```bash
-yum install libffi-devel
-```
-
-![takeoff](img/takeoff.jpg)

--- a/boris.toml
+++ b/boris.toml
@@ -1,11 +1,13 @@
 [boris]
   version = 1
 
+[build.dist-7-10]
+[build.dist-8-0]
 [build.dist-validate]
   command = [["validate-respect"]]
-[build.dist-7-10]
 
 [build.branches-7-10]
+[build.branches-8-0]
 
 [build.all-submodules]
   command = [["dangling-refs"]]

--- a/jetski.cabal
+++ b/jetski.cabal
@@ -20,7 +20,6 @@ library
                      , directory                       == 1.2.*
                      , exceptions                      >= 0.6        && < 0.9
                      , filepath                        == 1.4.*
-                     , libffi                          == 0.1.*
                      , memory                          == 0.13.*
                      , process                         >= 1.2.3      && < 1.5
                      , temporary                       == 1.2.*
@@ -38,6 +37,11 @@ library
                        Jetski
                        Jetski.Hash
                        Jetski.OS
+
+                       Jetski.Foreign.Argument
+                       Jetski.Foreign.Binding
+                       Jetski.Foreign.Function
+                       Jetski.Foreign.Return
 
 test-suite test
   type:                exitcode-stdio-1.0

--- a/jetski.cabal
+++ b/jetski.cabal
@@ -65,3 +65,32 @@ test-suite test
                      , quickcheck-instances            == 0.3.*
                      , text                            == 1.2.*
                      , transformers                    >= 0.3        && < 0.6
+
+test-suite test-dynamic
+  -- Cabal < 1.24 doesn't build this properly, but there's no way to do a
+  -- conditional based on the cabal version, the best we can do is use GHC as a
+  -- proxy because we know that GHC 8.0 requires at least Cabal 1.24.
+  if impl(ghc < 8.0)
+    buildable:         False
+
+  type:                exitcode-stdio-1.0
+
+  main-is:             test.hs
+
+  ghc-options:         -Wall -threaded -dynamic -O2
+
+  hs-source-dirs:
+                       test
+
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-disorder-core
+                     , ambiata-disorder-corpus
+                     , ambiata-jetski
+                     , ambiata-p
+                     , ambiata-x-eithert
+                     , containers                      == 0.5.*
+                     , QuickCheck                      >= 2.8.2      && < 2.9
+                     , quickcheck-instances            == 0.3.*
+                     , text                            == 1.2.*
+                     , transformers                    >= 0.3        && < 0.6

--- a/master.toml
+++ b/master.toml
@@ -9,8 +9,16 @@
   HADDOCK = "true"
   HADDOCK_S3 = "$AMBIATA_HADDOCK_MASTER"
 
+[build.dist-8-0]
+  GHC_VERSION = "8.0.1"
+  CABAL_VERSION = "1.24.0.0"
+
 [build.branches-7-10]
   GHC_VERSION = "7.10.2"
   CABAL_VERSION = "1.22.4.0"
   HADDOCK = "true"
   HADDOCK_S3 = "$AMBIATA_HADDOCK_BRANCHES"
+
+[build.branches-8-0]
+  GHC_VERSION = "8.0.1"
+  CABAL_VERSION = "1.24.0.0"

--- a/src/Jetski/Foreign/Argument.hs
+++ b/src/Jetski/Foreign/Argument.hs
@@ -1,0 +1,172 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Jetski.Foreign.Argument (
+    CArgument(..)
+  , Argument(..)
+  , storableArgument
+  , pointerArgument
+
+  , argInt8
+  , argInt16
+  , argInt32
+  , argInt64
+  , argWord8
+  , argWord16
+  , argWord32
+  , argWord64
+  , argFloat
+  , argDouble
+
+  , argCChar
+  , argCUChar
+  , argCWchar
+  , argCInt
+  , argCUInt
+  , argCLong
+  , argCULong
+  , argCSize
+  , argCTime
+
+  , argPtr
+  , argFunPtr
+  , argByteString
+  , argByteStringCopy
+  ) where
+
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Unsafe as B
+import           Data.Word (Word8, Word16, Word32, Word64)
+
+import           Foreign.C.Types (CChar, CUChar, CWchar)
+import           Foreign.C.Types (CInt, CUInt, CLong, CULong)
+import           Foreign.C.Types (CSize, CTime)
+import           Foreign.Marshal (malloc, free, new)
+import           Foreign.Ptr (Ptr, FunPtr, castPtr)
+import           Foreign.Storable (Storable(..))
+
+import           Jetski.Foreign.Binding
+
+import           P
+
+import           System.IO (IO)
+
+
+data CArgument =
+  CArgument {
+      argumentType :: !(Ptr CType)
+    , argumentValue :: !(Ptr CValue)
+    , argumentFree :: IO ()
+    }
+
+newtype Argument =
+  Argument {
+      allocArgument :: IO CArgument
+    }
+
+storableArgument :: Storable a => Ptr CType -> a -> Argument
+storableArgument typ a =
+  Argument $ do
+    p <- malloc
+    poke p a
+    return $
+      CArgument typ (castPtr p) (free p)
+
+pointerArgument :: (a -> IO (Ptr b)) -> (Ptr b -> IO ()) -> a -> Argument
+pointerArgument newA freeA a =
+  Argument $ do
+    p <- newA a
+    pp <- new p
+    return $
+      CArgument ffi_type_pointer (castPtr pp) (free pp >> freeA p)
+
+argInt8 :: Int8 -> Argument
+argInt8 =
+  storableArgument ffi_type_sint8
+
+argInt16 :: Int16 -> Argument
+argInt16 =
+  storableArgument ffi_type_sint16
+
+argInt32 :: Int32 -> Argument
+argInt32 =
+  storableArgument ffi_type_sint32
+
+argInt64 :: Int64 -> Argument
+argInt64 =
+  storableArgument ffi_type_sint64
+
+argWord8 :: Word8 -> Argument
+argWord8 =
+  storableArgument ffi_type_uint8
+
+argWord16 :: Word16 -> Argument
+argWord16 =
+  storableArgument ffi_type_uint16
+
+argWord32 :: Word32 -> Argument
+argWord32 =
+  storableArgument ffi_type_uint32
+
+argWord64 :: Word64 -> Argument
+argWord64 =
+  storableArgument ffi_type_uint64
+
+argFloat :: Float -> Argument
+argFloat =
+  storableArgument ffi_type_float
+
+argDouble :: Double -> Argument
+argDouble =
+  storableArgument ffi_type_double
+
+argCChar :: CChar -> Argument
+argCChar =
+  storableArgument ffi_type_schar
+
+argCUChar :: CUChar -> Argument
+argCUChar =
+  storableArgument ffi_type_uchar
+
+argCWchar :: CWchar -> Argument
+argCWchar =
+  storableArgument ffi_type_schar
+
+argCInt :: CInt -> Argument
+argCInt =
+  storableArgument ffi_type_sint
+
+argCUInt :: CUInt -> Argument
+argCUInt =
+  storableArgument ffi_type_uint
+
+argCLong :: CLong -> Argument
+argCLong =
+  storableArgument ffi_type_slong
+
+argCULong :: CULong -> Argument
+argCULong =
+  storableArgument ffi_type_ulong
+
+argCSize :: CSize -> Argument
+argCSize =
+  storableArgument ffi_type_size
+
+argCTime :: CTime -> Argument
+argCTime =
+  storableArgument ffi_type_time
+
+argPtr :: Ptr a -> Argument
+argPtr =
+  storableArgument ffi_type_pointer
+
+argFunPtr :: FunPtr a -> Argument
+argFunPtr =
+  storableArgument ffi_type_pointer
+
+argByteString :: ByteString -> Argument
+argByteString =
+  pointerArgument (flip B.unsafeUseAsCString return) (const $ return ())
+
+argByteStringCopy :: ByteString -> Argument
+argByteStringCopy =
+  pointerArgument (flip B.useAsCString return) (const $ return ())

--- a/src/Jetski/Foreign/Binding.hsc
+++ b/src/Jetski/Foreign/Binding.hsc
@@ -1,0 +1,164 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE EmptyDataDecls #-}
+module Jetski.Foreign.Binding where
+
+#include <ffi.h>
+
+import           Data.Word (Word32)
+
+import           Foreign.C.Types (CInt, CUInt(..), CLong, CULong)
+import           Foreign.C.Types (CWchar, CSize, CTime)
+import           Foreign.Storable (Storable(..))
+import           Foreign.Ptr (Ptr, FunPtr)
+
+import           P
+
+import qualified Prelude as Savage
+
+import           System.IO (IO)
+
+
+data CValue
+data CType
+data CIF
+
+type C_ffi_status =
+  (#type ffi_status)
+
+type C_ffi_abi =
+  (#type ffi_abi)
+
+ffi_default_abi :: C_ffi_abi
+ffi_default_abi =
+  #const FFI_DEFAULT_ABI
+
+ffi_ok :: C_ffi_status
+ffi_ok =
+  #const FFI_OK
+
+ffi_cif_size :: Int
+ffi_cif_size =
+  #size ffi_cif
+
+foreign import ccall safe "ffi_prep_cif"
+  ffi_prep_cif :: Ptr CIF -> C_ffi_abi -> CUInt -> Ptr CType -> Ptr (Ptr CType) -> IO C_ffi_status
+
+foreign import ccall safe "ffi_call"
+  ffi_call :: Ptr CIF -> FunPtr a -> Ptr CValue -> Ptr (Ptr CValue) -> IO ()
+
+foreign import ccall unsafe "&ffi_type_void"
+  ffi_type_void :: Ptr CType
+
+foreign import ccall unsafe "&ffi_type_sint8"
+  ffi_type_sint8 :: Ptr CType
+
+foreign import ccall unsafe "&ffi_type_uint8"
+  ffi_type_uint8 :: Ptr CType
+
+foreign import ccall unsafe "&ffi_type_uint16"
+  ffi_type_uint16 :: Ptr CType
+
+foreign import ccall unsafe "&ffi_type_sint16"
+  ffi_type_sint16 :: Ptr CType
+
+foreign import ccall unsafe "&ffi_type_uint32"
+  ffi_type_uint32 :: Ptr CType
+
+foreign import ccall unsafe "&ffi_type_sint32"
+  ffi_type_sint32 :: Ptr CType
+
+foreign import ccall unsafe "&ffi_type_uint64"
+  ffi_type_uint64 :: Ptr CType
+
+foreign import ccall unsafe "&ffi_type_sint64"
+  ffi_type_sint64 :: Ptr CType
+
+foreign import ccall unsafe "&ffi_type_float"
+  ffi_type_float  :: Ptr CType
+
+foreign import ccall unsafe "&ffi_type_double"
+  ffi_type_double :: Ptr CType
+
+foreign import ccall unsafe "&ffi_type_pointer"
+  ffi_type_pointer :: Ptr CType
+
+ffi_type_uchar :: Ptr CType
+ffi_type_uchar =
+  ffi_type_uint8
+
+ffi_type_schar :: Ptr CType
+ffi_type_schar =
+  ffi_type_sint8
+
+ffi_type_wchar :: Ptr CType
+ffi_type_wchar =
+  case sizeOf (Savage.undefined :: CWchar) of
+    2 ->
+      ffi_type_sint16
+    4 ->
+      ffi_type_sint32
+    8 ->
+      ffi_type_sint64
+    _ ->
+      Savage.error "Jetski.Foreign.Binding.ffi_type_wchar: unsupported size"
+
+ffi_type_uint :: Ptr CType
+ffi_type_uint =
+  case sizeOf (Savage.undefined :: CUInt) of
+    4 ->
+      ffi_type_uint32
+    8 ->
+      ffi_type_uint64
+    _ ->
+      Savage.error "Jetski.Foreign.Binding.ffi_type_uint: unsupported size"
+
+ffi_type_sint :: Ptr CType
+ffi_type_sint =
+  case sizeOf (Savage.undefined :: CInt) of
+    4 ->
+      ffi_type_sint32
+    8 ->
+      ffi_type_sint64
+    _ ->
+      Savage.error "Jetski.Foreign.Binding.ffi_type_sint: unsupported size"
+
+ffi_type_ulong :: Ptr CType
+ffi_type_ulong =
+  case sizeOf (Savage.undefined :: CULong) of
+    4 ->
+      ffi_type_uint32
+    8 ->
+      ffi_type_uint64
+    _ ->
+      Savage.error "Jetski.Foreign.Binding.ffi_type_ulong: unsupported size"
+
+ffi_type_slong :: Ptr CType
+ffi_type_slong =
+  case sizeOf (Savage.undefined :: CLong) of
+    4 ->
+      ffi_type_sint32
+    8 ->
+      ffi_type_sint64
+    _ ->
+      Savage.error "Jetski.Foreign.Binding.ffi_type_slong: unsupported size"
+
+ffi_type_size :: Ptr CType
+ffi_type_size =
+  case sizeOf (Savage.undefined :: CSize) of
+    4 ->
+      ffi_type_uint32
+    8 ->
+      ffi_type_uint64
+    _ ->
+      Savage.error "Jetski.Foreign.Binding.ffi_type_size: unsupported size"
+
+ffi_type_time :: Ptr CType
+ffi_type_time =
+  case sizeOf (Savage.undefined :: CTime) of
+    4 ->
+      ffi_type_sint32
+    8 ->
+      ffi_type_sint64
+    _ ->
+      Savage.error "Jetski.Foreign.Binding.ffi_type_time: unsupported size"

--- a/src/Jetski/Foreign/Function.hs
+++ b/src/Jetski/Foreign/Function.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Jetski.Foreign.Function (
+    call
+  ) where
+
+import           Foreign.Marshal (allocaBytes, withArray)
+import           Foreign.Ptr (FunPtr)
+
+import           Jetski.Foreign.Argument
+import           Jetski.Foreign.Binding
+import           Jetski.Foreign.Return
+
+import           P
+
+import qualified Prelude as Savage
+
+import           System.IO (IO)
+
+
+call :: FunPtr a -> Return b -> [Argument] -> IO b
+call funPtr (Return typ withRet) args0 =
+  allocaBytes ffi_cif_size $ \cif -> do
+    args <- traverse allocArgument args0
+    withArray (fmap argumentType args) $ \typesPtr -> do
+      status <- ffi_prep_cif cif ffi_default_abi (fromIntegral $ length args) typ typesPtr
+
+      unless (status == ffi_ok) $
+        Savage.error "Jetski.Foreign.Function.call: ffi_prep_cif failed"
+
+      withArray (fmap argumentValue args) $ \valuesPtr -> do
+        ret <- withRet $ \ptr -> ffi_call cif funPtr ptr valuesPtr
+        traverse_ argumentFree args
+        return ret

--- a/src/Jetski/Foreign/Return.hs
+++ b/src/Jetski/Foreign/Return.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Jetski.Foreign.Return (
+    Return(..)
+  , storableReturn
+  , withReturn
+
+  , retVoid
+  , retInt8
+  , retInt16
+  , retInt32
+  , retInt64
+  , retWord8
+  , retWord16
+  , retWord32
+  , retWord64
+  , retFloat
+  , retDouble
+
+  , retCChar
+  , retCUChar
+  , retCWchar
+  , retCInt
+  , retCUInt
+  , retCLong
+  , retCULong
+  , retCSize
+  , retCTime
+
+  , retPtr
+  , retFunPtr
+  , retByteString
+  , retByteStringCopy
+  ) where
+
+import           Data.Word (Word8, Word16, Word32, Word64)
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Unsafe as B
+
+import           Foreign.Marshal (alloca)
+import           Foreign.Ptr (Ptr, FunPtr, castPtr, nullPtr)
+import           Foreign.Storable (Storable(..))
+import           Foreign.C.Types (CChar, CUChar, CWchar)
+import           Foreign.C.Types (CInt, CUInt, CLong, CULong)
+import           Foreign.C.Types (CSize, CTime)
+
+import           Jetski.Foreign.Binding
+
+import           P
+
+import           System.IO (IO)
+
+
+data Return a =
+  Return {
+      returnType :: !(Ptr CType)
+    , returnWith :: (Ptr CValue -> IO ()) -> IO a
+    }
+
+instance Functor Return where
+  fmap f (Return typ withPoke) =
+    Return typ (fmap f . withPoke)
+
+withReturn :: (a -> IO b) -> Return a -> Return b
+withReturn f (Return typ withPoke) =
+  Return typ (withPoke >=> f)
+
+storableReturn :: Storable a => Ptr CType -> Return a
+storableReturn typ =
+  Return typ $ \write ->
+  alloca $ \ptr -> do
+    write (castPtr ptr)
+    peek ptr
+
+retVoid :: Return ()
+retVoid =
+  Return ffi_type_void $ \write -> do
+    write nullPtr
+    return ()
+
+retInt8 :: Return Int8
+retInt8 =
+  storableReturn ffi_type_sint8
+
+retInt16 :: Return Int16
+retInt16 =
+  storableReturn ffi_type_sint16
+
+retInt32 :: Return Int32
+retInt32 =
+  storableReturn ffi_type_sint32
+
+retInt64 :: Return Int64
+retInt64 =
+  storableReturn ffi_type_sint64
+
+retWord8 :: Return Word8
+retWord8 =
+  storableReturn ffi_type_uint8
+
+retWord16 :: Return Word16
+retWord16 =
+  storableReturn ffi_type_uint16
+
+retWord32 :: Return Word32
+retWord32 =
+  storableReturn ffi_type_uint32
+
+retWord64 :: Return Word64
+retWord64 =
+  storableReturn ffi_type_uint64
+
+retFloat :: Return Float
+retFloat =
+  storableReturn ffi_type_float
+
+retDouble :: Return Double
+retDouble =
+  storableReturn ffi_type_double
+
+retCChar :: Return CChar
+retCChar =
+  storableReturn ffi_type_schar
+
+retCUChar :: Return CUChar
+retCUChar =
+  storableReturn ffi_type_uchar
+
+retCWchar :: Return CWchar
+retCWchar =
+  storableReturn ffi_type_schar
+
+retCInt :: Return CInt
+retCInt =
+  storableReturn ffi_type_sint
+
+retCUInt :: Return CUInt
+retCUInt =
+  storableReturn ffi_type_uint
+
+retCLong :: Return CLong
+retCLong =
+  storableReturn ffi_type_slong
+
+retCULong :: Return CULong
+retCULong =
+  storableReturn ffi_type_ulong
+
+retCSize :: Return CSize
+retCSize =
+  storableReturn ffi_type_size
+
+retCTime :: Return CTime
+retCTime =
+  storableReturn ffi_type_time
+
+retFunPtr :: Return a -> Return (FunPtr a)
+retFunPtr _ =
+  storableReturn ffi_type_pointer
+
+retPtr :: Return a -> Return (Ptr a)
+retPtr _ =
+  storableReturn ffi_type_pointer
+
+retByteString :: Return B.ByteString
+retByteString =
+  withReturn B.packCString (retPtr retCChar)
+
+retByteStringCopy :: Return B.ByteString
+retByteStringCopy =
+  withReturn B.unsafePackMallocCString (retPtr retCChar)

--- a/test/Test/Jetski.hs
+++ b/test/Test/Jetski.hs
@@ -27,13 +27,13 @@ import           X.Control.Monad.Trans.Either (EitherT, runEitherT)
 
 ------------------------------------------------------------------------
 
-prop_library name (Arguments args) = testEitherT $ do
+prop_library name (Values args) = testEitherT $ do
   withLibrary extraOptions (source name args) $ \library -> do
-    f <- function library (unName name) retInt
+    f <- function library (unName name) retCInt
     _ <- liftIO (f (fmap ffiArg args))
     return (property succeeded)
 
-prop_assembly name (Arguments args) = testEitherT $ do
+prop_assembly name (Values args) = testEitherT $ do
   _ <- compileAssembly extraOptions (source name args)
   return (property succeeded)
 
@@ -43,7 +43,7 @@ prop_assembly name (Arguments args) = testEitherT $ do
 extraOptions :: [CompilerOption]
 extraOptions = ["-O11", "-march=native"]
 
-source :: Name -> [Argument] -> Text
+source :: Name -> [Value] -> Text
 source name args = T.unlines [
       "#include <stdint.h>"
     , ""
@@ -60,13 +60,13 @@ source name args = T.unlines [
            . ("42":)
            $ fmap nameOfArgument args
 
-ctype :: Argument -> Text
+ctype :: Value -> Text
 ctype = \case
   Double  _ _ -> "double"
   Int32   _ _ -> "int32_t"
   VoidPtr _ _ -> "void*"
 
-ffiArg :: Argument -> Arg
+ffiArg :: Value -> Argument
 ffiArg (Double  _ x) = argDouble x
 ffiArg (Int32   _ x) = argInt32  x
 ffiArg (VoidPtr _ x) = argPtr (intPtrToPtr x)

--- a/test/Test/Jetski/Arbitrary.hs
+++ b/test/Test/Jetski/Arbitrary.hs
@@ -23,16 +23,16 @@ import           Test.QuickCheck
 newtype Name = Name { unName :: Text }
   deriving (Eq, Ord, Show)
 
-data Argument =
+data Value =
     Double  Name Double
   | Int32   Name Int32
   | VoidPtr Name IntPtr
   deriving (Eq, Ord, Show)
 
-newtype Arguments = Arguments { getArguments :: [Argument] }
+newtype Values = Values { getArguments :: [Value] }
   deriving (Eq, Ord, Show)
 
-nameOfArgument :: Argument -> Text
+nameOfArgument :: Value -> Text
 nameOfArgument = \case
   Double  n _ -> unName n
   Int32   n _ -> unName n
@@ -41,11 +41,11 @@ nameOfArgument = \case
 
 ------------------------------------------------------------------------
 
-instance Arbitrary Arguments where
+instance Arbitrary Values where
   arbitrary =
-    Arguments . List.nubBy ((==) `on` nameOfArgument) <$> arbitrary
+    Values . List.nubBy ((==) `on` nameOfArgument) <$> arbitrary
 
-instance Arbitrary Argument where
+instance Arbitrary Value where
   arbitrary = oneof [
       Double  <$> arbitrary <*> arbitrary
     , Int32   <$> arbitrary <*> arbitrary


### PR DESCRIPTION
These bindings are based on the `libffi` package but I haven't taken some of the more advanced features (passing structs) and I've also tidied up the names of things a bit.

The reason for doing this is to avoid a dependency on the C libffi library, we don't need it, as libffi is statically linked in to every Haskell binary, so all we need to do is `foreign import` and we're set.

! @amosr @tranma 