### PR TITLE
Support Cabal 2.0 as well

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -37,7 +37,7 @@ main =
 genBuildInfo :: Verbosity -> PackageDescription -> IO ()
 genBuildInfo verbosity pkg = do
   createDirectoryIfMissingVerbose verbosity True "gen"
-  let (PackageName pname) = pkgName . package $ pkg
+  let pname = unPackageName . pkgName . package $ pkg
       version = pkgVersion . package $ pkg
       name = "BuildInfo_" ++ (map (\c -> if c == '-' then '_' else c) pname)
       targetHs = "gen/" ++ name ++ ".hs"

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,17 +1,43 @@
-#!/usr/bin/env runhaskell
+{-# LANGUAGE CPP #-}
 
 import           Data.Char (isDigit)
 import           Data.List (intercalate)
 import           Data.Monoid ((<>))
-import           Data.Version (showVersion)
 
+import           Distribution.InstalledPackageInfo
 import           Distribution.PackageDescription
-import           Distribution.Verbosity
-import           Distribution.Simple
+import           Distribution.Simple (buildHook, defaultMainWithHooks, pkgName, pkgVersion, preConf, replHook, sDistHook, simpleUserHooks, testHook)
 import           Distribution.Simple.Setup (BuildFlags(..), ReplFlags(..), TestFlags(..), fromFlag)
 import           Distribution.Simple.LocalBuildInfo
-import           Distribution.Simple.BuildPaths (autogenModulesDir)
+import           Distribution.Simple.PackageIndex
 import           Distribution.Simple.Utils (createDirectoryIfMissingVerbose, rewriteFile, rawSystemStdout)
+import           Distribution.Verbosity
+
+#if __GLASGOW_HASKELL__ <= 710
+-- GHC 7.10 and earlier do not support the MIN_VERSION_Cabal macro.
+#define MIN_VERSION_Cabal(a,b,c) 0
+#endif
+
+#if MIN_VERSION_Cabal(2,0,0)
+import           Distribution.Types.PackageName (PackageName, unPackageName)
+import           Distribution.Simple.BuildPaths (autogenPackageModulesDir)
+import           Distribution.Version (Version, versionNumbers)
+
+showVersion :: Version -> String
+showVersion = intercalate "." . fmap show . versionNumbers
+
+autogenModulesDirCompat :: LocalBuildInfo -> String
+autogenModulesDirCompat = autogenPackageModulesDir
+
+#else
+import           Distribution.Simple (PackageName, unPackageName)
+import           Distribution.Simple.BuildPaths (autogenModulesDir)
+import           Data.Version (showVersion)
+
+autogenModulesDirCompat :: LocalBuildInfo -> String
+autogenModulesDirCompat = autogenModulesDir
+#endif
+
 
 main :: IO ()
 main =
@@ -25,12 +51,15 @@ main =
        (sDistHook hooks) pd mlbi uh flags
    , buildHook = \pd lbi uh flags -> do
        genBuildInfo (fromFlag $ buildVerbosity flags) pd
+       genDependencyInfo (fromFlag $ buildVerbosity flags) pd lbi
        (buildHook hooks) pd lbi uh flags
    , replHook = \pd lbi uh flags args -> do
        genBuildInfo (fromFlag $ replVerbosity flags) pd
+       genDependencyInfo (fromFlag $ replVerbosity flags) pd lbi
        (replHook hooks) pd lbi uh flags args
    , testHook = \args pd lbi uh flags -> do
        genBuildInfo (fromFlag $ testVerbosity flags) pd
+       genDependencyInfo (fromFlag $ testVerbosity flags) pd lbi
        (testHook hooks) args pd lbi uh flags
    }
 
@@ -56,6 +85,30 @@ genBuildInfo verbosity pkg = do
     , "buildInfoVersion = \"" ++ buildVersion ++ "\""
     ]
   rewriteFile targetText buildVersion
+
+genDependencyInfo :: Verbosity -> PackageDescription -> LocalBuildInfo -> IO ()
+genDependencyInfo verbosity pkg info = do
+  let
+    pname = unPackageName . pkgName . package $ pkg
+    name = "DependencyInfo_" ++ (map (\c -> if c == '-' then '_' else c) pname)
+    targetHs = autogenModulesDirCompat info ++ "/" ++ name ++ ".hs"
+    render p =
+      let
+        n = unPackageName $ pkgName p
+        v = showVersion $ pkgVersion p
+      in
+       n ++ "-" ++ v
+    deps = fmap (render . sourcePackageId) . allPackages $ installedPkgs info
+    strs = flip fmap deps $ \d -> "\"" ++ d ++ "\""
+
+  createDirectoryIfMissingVerbose verbosity True (autogenModulesDirCompat info)
+
+  rewriteFile targetHs $ unlines [
+      "module " ++ name ++ " where"
+    , "import Prelude"
+    , "dependencyInfo :: [String]"
+    , "dependencyInfo = [\n    " ++ intercalate "\n  , " strs ++ "\n  ]"
+    ]
 
 gitVersion :: Verbosity -> IO String
 gitVersion verbosity = do


### PR DESCRIPTION
Since Cabal 2.0, PackageName is an opaque type, so this pattern match doesn't work.

http://hackage.haskell.org/package/Cabal-2.0.1.0/docs/Distribution-Types-PackageName.html

This change to Setup.hs allows jetski to build with more recent versions of the Cabal library.
/jury approved @tmcgilchrist @erikd-ambiata